### PR TITLE
Update README with correct name for status field

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,7 +21,7 @@ event describes an occurrence in the lifetime of a method. There are three types
 of method event: added, changed, deleted. Regardless of their type, each event
 contains the following information:
 
-* type - added, changed, or deleted
+* status - added, changed, or deleted
 * commit - sha1 of the git commit for the code change
 * date - date of the commit
 * file_name - name of the file containing the method


### PR DESCRIPTION
The documentation calls the field "type" but in the code it is actually "status"  for example in:  https://github.com/michaelfeathers/delta-flora/blob/6826f8bce62e47bfc757d772e3712a93d26b0907/lib/repository.rb#L105
